### PR TITLE
Abstract Types

### DIFF
--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -15,14 +15,10 @@ import config._
 
 object Server {
 
-  val load = Config.load()
-
   def stream[F[_]: ConcurrentEffect](implicit T: Timer[F], C: ContextShift[F]): Stream[F, Nothing] = {
-    val cfg = load.unsafeRunSync
-    
+
     for {
-      
-      //cfg <- Stream.eval(Config.load)
+      cfg <- Stream.eval(Config.load[F]())
 
       client <- BlazeClientBuilder[F](global).stream
       helloWorldAlg = HelloWorld.impl[F]

--- a/src/main/scala/config/package.scala
+++ b/src/main/scala/config/package.scala
@@ -1,5 +1,5 @@
 
-import cats.effect.IO
+import cats.effect.Sync
 import java.nio.file.{Path, Paths}
 import pureconfig._
 import pureconfig.generic.auto._
@@ -18,7 +18,7 @@ package object config {
 
     val configFile  = Paths.get ("./src/main/resources/application.conf")
 
-    def load(path: Path = configFile): IO[Config] = loadConfigF[IO,Config](path)
+    def load[F[_]: Sync](path: Path = configFile): F[Config] = loadConfigF[F,Config](path)
 
   }
 }


### PR DESCRIPTION
Were trying to pull in hard-coded `IO` into a stream defined over an abstract `F[_]` since those were not the same it had a type error, correctly so. Allowing the method to be abstract resolved the issue.